### PR TITLE
fix: make get-prospect-by-id and get-prospect-by-email use POST

### DIFF
--- a/snovio/__init__.py
+++ b/snovio/__init__.py
@@ -24,7 +24,6 @@ class SnovioAPI:
         'domain-emails-with-info',
         'prospect-finished', 'get-emails-replies', 'get-emails-clicked',
         'get-user-campaigns', 'emails-sent',
-        'get-prospect-by-id', 'get_prospects_by_email',
         'prospect-custom-fields', 'get-user-lists',
         'get-balance'
     ]


### PR DESCRIPTION
The API https://snov.io/api#FindProspectbyID shows these
need POST, not GET