### PR TITLE
fix: remove print in library

### DIFF
--- a/snovio/__init__.py
+++ b/snovio/__init__.py
@@ -79,7 +79,6 @@ class SnovioAPI:
             return response
 
         elif response.status_code == 401:
-            print('Refreshing token')
             if self.is_parameter_in_uri(endpoint):
                 endpoint = self.update_endpoint_with_query_params(endpoint, data)
                 data = {}


### PR DESCRIPTION
We don't need diagnostic prints showing up in applications
calling the library. Since its not a logger we can't override
either.